### PR TITLE
refactor(ccs): port pandita2 permutator to C++

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -673,6 +673,7 @@ dependencies = [
 name = "cycle_combination_solver"
 version = "0.1.0"
 dependencies = [
+ "cc",
  "cfg_aliases",
  "enum_dispatch",
  "fastrand",

--- a/src/cycle_combination_solver/Cargo.toml
+++ b/src/cycle_combination_solver/Cargo.toml
@@ -23,6 +23,7 @@ pretty_env_logger.workspace = true
 test-log.workspace = true
 
 [build-dependencies]
+cc = "1"
 cfg_aliases = "0.2.1"
 
 [lints]

--- a/src/cycle_combination_solver/build.rs
+++ b/src/cycle_combination_solver/build.rs
@@ -50,4 +50,12 @@ fn main() {
         // avx2: { not(l) }, // true
         // avx2: { l }, // false
     }
+
+    println!("cargo:rerun-if-changed=cpp/permutator.cpp");
+    println!("cargo:rerun-if-changed=cpp/permutator.h");
+    cc::Build::new()
+        .cpp(true)
+        .std("c++17")
+        .file("cpp/permutator.cpp")
+        .compile("qter_permutator");
 }

--- a/src/cycle_combination_solver/cpp/permutator.cpp
+++ b/src/cycle_combination_solver/cpp/permutator.cpp
@@ -1,0 +1,39 @@
+#include "permutator.h"
+
+#include <utility>
+
+namespace {
+
+/// Reverse the elements in `perm` from index `s` to index `e`, inclusive.
+///
+/// # Safety
+///
+/// `s` and `e` must be valid indices for `perm`, and `s` must be less than or
+/// equal to `e`.
+void reverse_unchecked(uint8_t *perm, size_t s, size_t e) {
+    while (s < e) {
+        std::swap(perm[s], perm[e]);
+        s += 1;
+        e -= 1;
+    }
+}
+
+} // namespace
+
+void qter_pandita2(uint8_t *perm, size_t len) {
+    // Benchmarked on a 2025 Mac M4: 170.49ns (test_big) 2.84ns (test_small)
+
+    size_t i = len - 2;
+    while (perm[i] >= perm[i + 1]) {
+        if (i == 0) {
+            return;
+        }
+        i -= 1;
+    }
+    size_t j = len - 1;
+    while (perm[j] <= perm[i]) {
+        j -= 1;
+    }
+    std::swap(perm[i], perm[j]);
+    reverse_unchecked(perm, i + 1, len - 1);
+}

--- a/src/cycle_combination_solver/cpp/permutator.h
+++ b/src/cycle_combination_solver/cpp/permutator.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+extern "C" {
+/// Use an alternative implementation of the Pandita algorithm to compute the
+/// next lexicographic permutation of a buffer. From:
+/// https://www.geeksforgeeks.org/lexicographic-permutations-of-string/
+///
+/// # Safety
+///
+/// `perm` must point to at least `len` bytes, `len` must be at least two, and
+/// the buffer must contain unique elements.
+void qter_pandita2(uint8_t *perm, size_t len);
+}

--- a/src/cycle_combination_solver/src/permutator.rs
+++ b/src/cycle_combination_solver/src/permutator.rs
@@ -1,33 +1,6 @@
-use std::ptr;
-
-/// Reverse the elements in the slice `perm` from index `s` to index `e`,
-/// inclusive.
-///
-/// # Safety
-///
-/// `s` and `e` must be valid indices for `perm`, and `s` must be less than or
-/// equal to `e`.
-unsafe fn reverse_unchecked(perm: &mut [u8], mut s: usize, mut e: usize) {
-    while s < e {
-        // SAFETY: `perm` is a mutable slice, and `s` and `e` are valid indices
-        // for `perm` by the caller
-        unsafe {
-            swap_unchecked(perm, s, e);
-        }
-        s += 1;
-        e -= 1;
-    }
-}
-
-/// Swaps the elements at indices `i` and `j` in the slice `perm`.
-///
-/// # Safety
-///
-/// `i` and `j` must be valid indices for `perm`
-unsafe fn swap_unchecked(perm: &mut [u8], i: usize, j: usize) {
-    unsafe {
-        ptr::swap(perm.as_mut_ptr().add(i), perm.as_mut_ptr().add(j));
-    }
+unsafe extern "C" {
+    /// Implemented in `cpp/permutator.cpp`, compiled and linked by `build.rs`.
+    fn qter_pandita2(perm: *mut u8, len: usize);
 }
 
 /// Use an alternative implementation of the Pandita algorithm to compute the
@@ -37,25 +10,10 @@ unsafe fn swap_unchecked(perm: &mut [u8], i: usize, j: usize) {
 ///
 /// `perm` must have length at least two and must contain unique elements.
 pub unsafe fn pandita2(perm: &mut [u8]) {
-    // Benchmarked on a 2025 Mac M4: 170.49ns (test_big) 2.84ns (test_small)
-
-    let len = perm.len();
-    let mut i = len - 2;
-    // SAFETY: The safety backed by the correctness of the implementation of the
-    // given algorithm
+    // SAFETY: `perm` is a valid buffer of `perm.len()` bytes, and the caller
+    // upholds the length and uniqueness requirements
     unsafe {
-        while perm.get_unchecked(i) >= perm.get_unchecked(i + 1) {
-            if i == 0 {
-                return;
-            }
-            i -= 1;
-        }
-        let mut j = len - 1;
-        while perm.get_unchecked(j) <= perm.get_unchecked(i) {
-            j -= 1;
-        }
-        swap_unchecked(perm, i, j);
-        reverse_unchecked(perm, i + 1, len - 1);
+        qter_pandita2(perm.as_mut_ptr(), perm.len());
     }
 }
 


### PR DESCRIPTION
## Summary

Deletes the Rust implementation of the Pandita next-lexicographic-permutation algorithm (`cycle_combination_solver/src/permutator.rs`) and fully ports it to C++, integrated into the cargo build.

- **`cpp/permutator.cpp` / `cpp/permutator.h`** — exact translation of `pandita2` and its `reverse_unchecked` helper, exposed as `extern "C" void qter_pandita2(uint8_t *perm, size_t len)`.
- **`build.rs`** — compiles and links the C++ file via the `cc` crate (`c++17`), alongside the existing `cfg_aliases` setup.
- **`src/permutator.rs`** — now a thin FFI binding: the `pub unsafe fn pandita2(&mut [u8])` signature, doc comment, and safety contract are preserved, so `pruning.rs` and `lib.rs` need zero changes.

## Logical equivalence

The existing exhaustive test is kept unchanged and now exercises the C++ implementation through the FFI boundary: `test_pandita2` checks every one of the 120 permutations of 5 elements and 24 permutations of 4 elements in lexicographic order. Both `#[bench]`es are also kept.

## Testing

- `cargo build -p cycle_combination_solver` — C++ compiles and links cleanly.
- `cargo test -p cycle_combination_solver --lib pandita2` — passes.
- Full crate suite: 52 passed, 11 ignored, 3 failed — the 3 failures (`test_induces_sorted_cycle_structure_many`, `test_induces_sorted_cycle_structure_within_cycle`, `test_3x3_corners_pruning_table`) fail identically on a clean `main` checkout (verified by stashing this change and re-running), so they are pre-existing and unrelated.
- `cargo clippy` and `cargo fmt --check` clean for the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DrXm44tbdU153n7VePNRWd